### PR TITLE
Small typos

### DIFF
--- a/chapter00-genesis.jsh
+++ b/chapter00-genesis.jsh
@@ -9,7 +9,7 @@
 // ## Types
 // A primitive type is stored as value while an object is stored as
 // a reference (the address of the object in memory).
-// In Java, `var` create a new variable
+// In Java, `var` creates a new variable
 var maxIntensity = 1.0;   // it's a value
 var colorName = "black";  // it's a reference to String somewhere in memory
 
@@ -35,8 +35,8 @@ System.out.println("the value of colorName is " + colorName);
 record Light(String color, double intensity) {}
 
 // ### Object creation with `new`
-// To create an object in memory, we use the operator `new` followed by the value of each record components
-// the following instruction create a Light with "blue" as color and 1.0 as intensity.
+// To create an object in memory, we use the operator `new` followed by the value of each record component.
+// The following instruction creates a Light with "blue" as color and 1.0 as intensity.
 var blueLight = new Light("blue", 1.0);
 System.out.println(blueLight);
 
@@ -58,7 +58,7 @@ System.out.println(blueLight.toString());
 System.out.println(blueLight);
 
 // ### equals()
-// In Java, you can ask if two objects are equals, using the method equals(Object).
+// In Java, you can ask if two objects are equal, using the method equals(Object).
 // The return value is a boolean (a primitive type that is either true or false).
 var redLight = new Light("red", 0.5);
 var redLight2 = new Light("red", 0.5);
@@ -83,4 +83,4 @@ System.out.println(greenLight2.hashCode());
 // call on an object using the operator `.`.
 // A Record defines methods to access the value of a component, and also
 // `toString()` to get the textual representation of an object and
-// `equals()` and `hashCode()` to test if two objects are equals.
+// `equals()` and `hashCode()` to test if two objects are equal.


### PR DESCRIPTION
A few small typos. The one I'm not sure you'll agree with is to reword "equals" to "equal". We cannot say that two objects "equals" each other. We could say that an object equals another.